### PR TITLE
add css for better mobile support

### DIFF
--- a/apps/news/news.arc
+++ b/apps/news/news.arc
@@ -580,7 +580,7 @@
            (userstyle ,gu)
            (usertheme, gu)
            (gentag link "rel" "icon" "href" "/favicon.ico")
-           (gentag "meta" "name" "viewport" "value" "width=device-width")
+           (gentag "meta" "name" "viewport" "content" "width=device-width, initial-scale=1")
            (tag (script "type" "text/javascript" "src" "/news.js"))
            (tag title (pr (+ this-site* (if ,gt (+ bar* ,gt) "")))))
            (tag body 

--- a/apps/news/static/default.css
+++ b/apps/news/static/default.css
@@ -1,8 +1,11 @@
 @import url("layout.css");
 
 body {
-    background-color: #ffffff;  
-    color:#000000;
+  color:#000000;
+  margin: 0;
+  width: 100%;
+  height: 100vh;
+  overflow: scroll;
 }
 
 a:link    {color:#000000;}

--- a/apps/news/static/layout.css
+++ b/apps/news/static/layout.css
@@ -1,72 +1,96 @@
-body  { font-family:Verdana, Geneva, sans-serif; font-size:10pt; }
+body  {
+  font-family:Verdana, Geneva, sans-serif;
+  font-size:  calc( (1rem) * 10 / 12 );
+}
 
 a:link { text-decoration:none; color:#828282; }
 a:visited { text-decoration:none; color:#000000; }
 
-.subtext { font-size:85%; padding-left: 15px; left:1.4em; margin-bottom: 0.5em; color:#828282 }
+.subtext { font-size:85%; padding-left: 1em; left:1.4em; margin-bottom: 0.5em; color:#828282 }
 
 form {
 	padding-top:1em;
 	padding-bottom:1em;
-	padding-left:2em;
+  padding-left: 1em;
+  padding-right: 1em;
+
+  @media (min-width: 640px) {
+    padding-left:2em;
+    padding-right:2em;
+  }
+}
+
+input[type='text'], input[type='number'], textarea {
+  max-width: 100%;
+}
+
+td > input[type='text'], td > input[type='number'], td > textarea {
+  max-width: 80%;
+}
+
+form[method=post] tr td {
+  max-width: 70%;
 }
 
 .layout {
-	width:85%;
-	min-width:85%;
-	margin:0px auto;
-	display:block;
+  background-color: #ddd;
+  margin: 0 auto;
+  max-width: 1024px;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .page-header,.page-footer {
-    display: block;
-    padding-top: 2px;
-    padding-bottom: 2px;
-    height: 18px;
+    min-height: 1.5em;
+    width: 100%;
     margin: 0 auto;
-    padding-left: 2px;
+    flex-basis: fit-content;
 }
 
 .page-header a:visited { color:#000000; }
 
 #logo {
-	margin-right:4px;
+	margin-right: 0.25em;
 }
 
 #page-title {
 	position:relative;
-	bottom:4px;
+	bottom: 0.25em;
 	font-weight:bold;
 }
 
 li.no-number { list-style-type: none; }
 
-#navmain {
-	width:auto;
-	padding-left:1em;
-	position:relative;
-	height:10px;
-	border:0;
-	margin-top:0;
-	margin-bottom:0;
-	bottom:4px;
+.page-header {
+  display: flex;
 }
 
-#navright {
-	float:right;
-	margin-right:0.5em;
-	padding-left:1em;
+.page-header > * {
+  padding: 0.125em 0.25em;
+  line-height: 1.5em;
+}
+
+.page-footer > * {
+  display: block;
+  line-height: 1.5em;
+  padding: 0.125em 0.25em;
+}
+
+#navmain {
+  flex-grow: 1;
 }
 
 .page-content {
-    padding-top: 4px;
-    padding-bottom: 2px;
+    padding-top: 0.25em;
+    padding-bottom: 0.125em;
+    display: block;
+    flex-grow: 1;
 }
 
 .comments-list, .threads-list {
   margin-left:2em;
-  padding-left:0px;
-  margin-bottom:1em;
+  padding-left:0;
 }
 
 .comments-list li, .threads-list li {
@@ -74,9 +98,14 @@ li.no-number { list-style-type: none; }
 }
 
 .items-list {
-    margin-block-start: 0px;
-    margin-block-end: 0px;
-    margin-left: 0px;
+    margin-block-start: 0;
+    margin-block-end: 0;
+    margin-left: 0;
+    display: block;
+}
+
+.items-list-item:not(:last-child) {
+  padding-bottom: 0.5em;
 }
 
 .items-list-item::marker {
@@ -85,12 +114,10 @@ li.no-number { list-style-type: none; }
 
 .itemhead {
 	margin-bottom:0.2em;
-} 
+}
 
 .comment {
-	padding-top: 0.5em;
-	padding-bottom: 0.25em;
-	margin-left: 1.4em;
+  padding: 0.5em 0.5em 0.5em 1.4em;
 }
 
 .comfoot {
@@ -128,13 +155,13 @@ li.no-number { list-style-type: none; }
 }
 
 .votearrow {
-  width:      10px;
-  height:     10px;
-  border:     0px;
-  margin:     2px 2px 6px;
+  width:      0.625em;
+  height:     0.625em;
+  border:     0;
+  margin:     0.125em 0.125em 0.375em;
   no-repeat;
   background: url("triangle.svg"), linear-gradient(transparent, transparent) no-repeat;
-  background-size: 10px;
+  background-size: 0.625em;
 }
 
 .rotate180 {
@@ -167,12 +194,7 @@ li.no-number { list-style-type: none; }
 @media only screen
 and (min-width : 300px)
 and (max-width : 750px) {
-  .layout { width: 100%; min-width: 0; }
-  body { padding: 0; margin: 0; width: 100%; }
   li { height: inherit !important; }
-  .title, .comment { font-size: inherit;  }
-  div.page-header { display: block; margin: 3px 5px; font-size: 12px; line-height: normal }
-  div.page-header b { display: block; font-size: 15px; }
   img[src='s.gif'][width='40'] { width: 12px; }
   img[src='s.gif'][width='80'] { width: 24px; }
   img[src='s.gif'][width='120'] { width: 36px; }
@@ -194,8 +216,6 @@ and (max-width : 750px) {
   img[src='s.gif'][width='760'] { width: 228px; }
   img[src='s.gif'][width='800'] { width: 240px; }
   img[src='s.gif'][width='840'] { width: 252px; }
-  .title { font-size: 11pt; line-height: 14pt;  }
-  .subtext { font-size: 9pt; }
   .votearrow { transform: scale(1.3,1.3); margin-right: 6px; }
   .votearrow.rotate180 {
     -webkit-transform: rotate(180deg) scale(1.3,1.3);  /* Chrome and other webkit browsers */
@@ -204,7 +224,6 @@ and (max-width : 750px) {
     -ms-transform:     rotate(180deg) scale(1.3,1.3);  /* IE9 */
     transform:         rotate(180deg) scale(1.3,1.3);  /* W3C complaint browsers */
   }
-  .votelinks { min-width: 18px; }
-  .votelinks a { display: block; margin-bottom: 9px; }
-  input[type='text'], input[type='number'], textarea { font-size: 16px; width: 90%; }
+  .votelinks { min-width: 1.125em; }
+  .votelinks a { display: block; margin-bottom: 0.5em; }
 }


### PR DESCRIPTION
This is a PR in response to [this post](https://twostopbits.com/item?id=251)

It adds css for better mobile support. This is absolutely nowhere near where I'd like this to be, but it is huge step in the right direction. I'd rather "better" than "nothing" at least for today.

The most notable changes are as follows:
- page has minimum height of device window
- `.layout` is now the device width, with a max-width of 1024px which helps readability for desktop as well
- the top level `10px` is now computed as "10/12 the system font", and all nested fonts are in `em` instead of `px`. This might look wonky if your system font is enlarged but it _should_ scale instead of ignore those settings
- removes a lot of `margin` definitions, as those really muck with layouts
- uses `flex` and `flex-grow` instead of floats and absolutes. A huge preference of mine, but if you hate it that's ok, you can pass on this PR

A lot more could be done, but I really wanted to keep this PR to css changes only and not changing the structure of the html generated by arc.